### PR TITLE
Feature/64/add fuel to planes

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -138,43 +138,54 @@
                 <th class="py-1 px-2">
                   To
                 </th>
+                <th class="py-1 px-2">
+                  Fuel
+                </th>
               </tr>
             </thead>
             <tbody class="text-xs">
               <tr
                 v-for="(plane, index) in schedule"
-                :key="plane.id"
-                :class="plane.landed ? 'opacity-50' : selectedPlane && (selectedPlane._id === plane.id) ? 'bg-sky-500' : index % 2 === 0 ? 'bg-slate-50 hover:bg-slate-100' : 'hover:bg-slate-100'"
+                :key="plane._id"
+                :class="plane._landed ? 'opacity-50' : selectedPlane && (selectedPlane._id === plane._id) ? 'bg-sky-500' : index % 2 === 0 ? 'bg-slate-50 hover:bg-slate-100' : 'hover:bg-slate-100'"
                 class="cursor-pointer transition-colors"
-                @click="plane.landed ? null : selectPlane(plane.id, index)"
+                @click="plane._landed ? null : selectPlane(plane._id, index)"
               >
                 <td class="py-1 px-2">
                   <div
                     class="inline-block rounded-full border px-2 "
-                    :class="plane.startTime < BoardScene._tick.value ? 'bg-green-100 border-green-300 text-green-700' : plane.startTime === BoardScene._tick.value ? 'bg-orange-100 border-orange-300 text-orange-700' : 'bg-blue-100 border-blue-300 text-blue-700'"
+                    :class="plane._startTime < BoardScene._tick.value ? 'bg-green-100 border-green-300 text-green-700' : plane._startTime === BoardScene._tick.value ? 'bg-orange-100 border-orange-300 text-orange-700' : 'bg-blue-100 border-blue-300 text-blue-700'"
                   >
-                    {{ formatTime(plane.startTime) }}
+                    {{ formatTime(plane._startTime) }}
                   </div>
                 </td>
                 <td class="py-1 px-2">
                   <div class="p-2 font-bold">
-                    {{ plane.startTime > BoardScene._tick.value ? 'Scheduled': plane.startTime === BoardScene._tick.value ? 'Approaching' : plane.landed ? 'Passed' : 'In flight' }}
+                    {{ plane._startTime > BoardScene._tick.value ? 'Scheduled': plane._startTime === BoardScene._tick.value ? 'Approaching' : plane._landed ? 'Passed' : 'In flight' }}
                   </div>
                 </td>
                 <td class="py-1 px-2">
                   <div
                     class="inline-block rounded-full border px-2"
-                    :class="plane.start.name.substring(0, 2) === 'AP' ? 'bg-orange-100 border-orange-300 text-orange-700' : 'bg-blue-100 border-blue-300 text-blue-700'"
+                    :class="plane._start.name.substring(0, 2) === 'AP' ? 'bg-orange-100 border-orange-300 text-orange-700' : 'bg-blue-100 border-blue-300 text-blue-700'"
                   >
-                    {{ plane.start.name }}
+                    {{ plane._start.name }}
                   </div>
                 </td>
                 <td class="py-1 px-2">
                   <div
                     class="inline-block rounded-full border px-2"
-                    :class="plane.end.name.substring(0, 2) === 'AP' ? 'bg-orange-100 border-orange-300 text-orange-700' : 'bg-blue-100 border-blue-300 text-blue-700'"
+                    :class="plane._end.name.substring(0, 2) === 'AP' ? 'bg-orange-100 border-orange-300 text-orange-700' : 'bg-blue-100 border-blue-300 text-blue-700'"
                   >
-                    {{ plane.end.name }}
+                    {{ plane._end.name }}
+                  </div>
+                </td>
+                <td class="py-1 px-2">
+                  <div
+                    class="inline-block rounded-full border px-2"
+                    :class="plane._fuel < 10 ? 'bg-red-100 border-red-300 text-red-700' : plane._fuel < 20 ? 'bg-orange-100 border-orange-300 text-orange-700' : 'bg-green-100 border-green-300 text-green-700'"
+                  >
+                    {{ plane._fuel }}
                   </div>
                 </td>
               </tr>
@@ -251,7 +262,13 @@ import BoardScene from '#/classes/scenes/board-scene'
 const { state, send, service } = useMachine(mainMachine)
 
 const scheduleOpen = ref(true)
-const schedule = computed(() => BoardScene._board._airplanesQueue)
+const schedule = computed(() => {
+  return BoardScene._board._airplanesQueue.map(plane => {
+    const n = BoardScene._airplanes.value.find((a) => a._id === plane._id)
+
+    return n || plane
+  })
+})
 
 const time = computed(() => formatTime(BoardScene._tick.value))
 

--- a/src/classes/base/game-board.js
+++ b/src/classes/base/game-board.js
@@ -173,16 +173,17 @@ export default class GameBoard {
 
       // Add airplanes to the queue
       this._airplanesQueue.push({
-        id: uuidv4(),
-        start,
-        end,
-        startTime: randomRoundNumber(0, 96),
+        _id: uuidv4(),
+        _start: start,
+        _end: end,
+        _startTime: randomRoundNumber(0, 96),
+        _fuel: randomRoundNumber(20, 35),
       })
     }
 
     // Sort the planes by startTime
     this._airplanesQueue.sort((plane1, plane2) => {
-      return plane1.startTime < plane2.startTime ? -1 : plane1.startTime > plane2.startTime ? 1 : 0
+      return plane1._startTime < plane2._startTime ? -1 : plane1._startTime > plane2._startTime ? 1 : 0
     })
   }
 }

--- a/src/classes/base/scene.js
+++ b/src/classes/base/scene.js
@@ -124,8 +124,8 @@ export default class GameScene {
     this._airplanes.value = this._airplanes.value.filter(plane => plane._id !== airplane._id)
 
     this._board._airplanesQueue.map(plane => {
-      if (plane.id === airplane._id) {
-        plane.landed = true
+      if (plane._id === airplane._id) {
+        plane._landed = true
       }
 
       return plane

--- a/src/classes/pieces/airplane.js
+++ b/src/classes/pieces/airplane.js
@@ -283,6 +283,10 @@ const createDefaultPlane = (color) => {
  */
 export default class Airplane {
 
+  _start = null
+  _end = null
+  _startTime = 0
+
   /**
    * The current position of the airplane.
    */
@@ -368,20 +372,31 @@ export default class Airplane {
   _tick = 0
 
   /**
+   * Tracks the amout of fuel this plane has.
+   */
+  _fuel = 0
+
+  /**
    * AnimateIn
    * AnimateOut
    * AnimateIdle
    */
-  constructor (position, direction, endPosition, endDirection, id) {
-    this._position = position
-    this._direction = direction
-    this._endPosition = endPosition
-    this._endDirection = endDirection
+  // constructor (position, direction, endPosition, endDirection, id, fuel, start, end) {
+  constructor (options) {
+    const { id, start, end, fuel, startTime } = options
+    this._start = start
+    this._end = end
+    this._position = start.position
+    this._direction = start.direction
+    // this._endPosition = endPosition
+    // this._endDirection = endDirection
     this._targetAltitude = this._position.y || 1
     this._takenOff = this._position.y !== 0
     this._id = id
-    this._name = `GJK`
+    this._name = 'GJK'
     this._color = new Color(Math.random() * 0xffffff)
+    this._fuel = fuel
+    this._startTime = startTime
 
     this.create()
 
@@ -439,16 +454,6 @@ export default class Airplane {
           .delay(delay)
           .start()
       }
-
-      // this.updateAnimation(from)
-
-      // new TWEEN.Tween(from)
-      //   .to(to, speed)
-      //   .easing(TWEEN.Easing.Elastic.Out)
-      //   .onUpdate(() => this.updateAnimation(from))
-      //   .onComplete(resolve)
-      //   .delay(delay)
-      //   .start()
     })
   }
 
@@ -568,11 +573,14 @@ export default class Airplane {
 
     // Check if the plane has reached its destination with poor man's deep equal.
     if (
-      JSON.stringify(this._position) === JSON.stringify(this._endPosition) &&
-      this._direction === this._endDirection
+      JSON.stringify(this._position) === JSON.stringify(this._end.position) &&
+      this._direction === this._end.direction
     ) {
       console.log('yay, plane landed at target!')
     }
+
+    // Reduce the plane's fuel
+    this._fuel -= 1
   }
 
   async animateNext (nextAlt, nextDir, delay = 0, scale = 1) {

--- a/src/classes/scenes/board-scene.js
+++ b/src/classes/scenes/board-scene.js
@@ -93,6 +93,7 @@ boardScene.nextTick = async () => {
     // boardScene.checkCollisions()
     boardScene.checkDestinations()
     boardScene.checkOutOfBounds()
+    boardScene.checkOutOfFuel()
 
     boardScene._isAnimating = false
   }
@@ -197,6 +198,15 @@ boardScene.checkOutOfBounds = () => {
       boardScene._score.value -= 500
 
       boardScene.removeAirplane(plane)
+    }
+  })
+}
+
+boardScene.checkOutOfFuel = () => {
+  boardScene._airplanes.value.forEach(plane => {
+    if (plane._fuel <= 0) {
+      console.log('game over!')
+      gameService.send('LOSE')
     }
   })
 }

--- a/src/classes/scenes/board-scene.js
+++ b/src/classes/scenes/board-scene.js
@@ -174,7 +174,7 @@ boardScene.checkDestinations = () => {
       const endD = plane._endPosition
 
       if (curX === endX && curY === endY && curZ === endZ && curD === endD) {
-        boardScene._score.value += 100
+        boardScene._score.value += 100 + (plane._fuel * 10)
 
         plane.setGhost()
       } else if (curY === 0) {

--- a/src/classes/scenes/board-scene.js
+++ b/src/classes/scenes/board-scene.js
@@ -72,11 +72,18 @@ boardScene.nextTick = async () => {
 
     // Move existing planes every 15 minutes
     const moves = Promise.all(boardScene._airplanes.value.map(plane => plane.next()))
-    const spawns = Promise.all(boardScene._board._airplanesQueue.filter(plane => plane.startTime === boardScene._tick.value).map(plane => {
-      const airplane = new Airplane(plane.start.position, plane.start.direction, plane.end.position, plane.end.direction, plane.id)
+
+    const spawns = Promise.all(boardScene._board._airplanesQueue.filter(plane => plane._startTime === boardScene._tick.value).map(plane => {
+      const airplane = new Airplane({
+        id: plane._id,
+        start: plane._start,
+        end: plane._end,
+        fuel: plane._fuel,
+        startTime: plane._startTime,
+      })
       boardScene.addAirplane(airplane)
       airplane.setGhost()
-      return airplane.animateIn(0, 1000)
+      return airplane.animateIn(0, 500)
     }))
 
     await moves

--- a/src/classes/scenes/intro-scene.js
+++ b/src/classes/scenes/intro-scene.js
@@ -61,7 +61,13 @@ introScene.start = () => {
   new RandomTile()
 
   // Add an airplane.
-  const airplane = new Airplane({ x: 0, y: 1, z: 0 }, 1, { x: 0, y: 0, z: 0 }, 1, 0)
+  const airplane = new Airplane({
+    id: 0,
+    start: { position: { x: 0, y: 1, z: 0 }, direction: 1, name: '' },
+    end: { position: { x: 0, y: 0, z: 0 }, direction: 1, name: '' },
+    fuel: 100,
+  })
+
   introScene.addAirplane(airplane)
 
   // Add the dirt base.


### PR DESCRIPTION
## What this PR does
- Adds fuel to planes
- Makes fuel a scoring factor
- Planes with no fuel will lose you the game
- Refactors the queue and airplane options to be synced better

## Related issues
Closes #64 
Closes #72 
