### PR TITLE
feat: :sparkles: Reset camera when plane is removed

### DIFF
--- a/src/controls.js
+++ b/src/controls.js
@@ -1,4 +1,7 @@
 import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls'
+import { Vector3 } from 'three'
+import TWEEN from '@tweenjs/tween.js'
+
 import camera from '#/camera'
 import renderer from '#/renderer'
 
@@ -9,5 +12,17 @@ controls.enableZoom = true
 controls.enablePan = false
 controls.autoRotate = true
 controls.autoRotateSpeed = -2
+
+const origin = new Vector3(0, 0, 0)
+export const resetControls = () => {
+  const from = controls.target
+  const to = origin
+
+  new TWEEN.Tween(from)
+    .to(to, 500)
+    .easing(TWEEN.Easing.Cubic.InOut)
+    .onUpdate(() => controls.target = from)
+    .start()
+}
 
 export default controls


### PR DESCRIPTION
## What this PR does
- Resets the camera when an airplane is selected but then removed from the board

## Related issues
Closes #91 
